### PR TITLE
Bump clamper to 1.02 and version to 1.04

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-clamp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Multiline text ellipsis for react",
   "main": "src/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/vsubbotskyy/React-dotdotdot#readme",
   "dependencies": {
-    "clamper": "1.0.1"
+    "clamper": "1.0.2"
   },
   "peerDependencies": {
     "react": "^0.14.3",


### PR DESCRIPTION
Clamper 1.01 had a forgotten debugger in it.  Bumping the version in React-dotdotdot to where it was removed.

https://github.com/vsubbotskyy/Clamp.js/commit/1c30f07a11840d43bfccd03f0af54bfd6cb15ae5
