### PR TITLE
Use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "homepage": "https://github.com/vsubbotskyy/React-dotdotdot#readme",
   "dependencies": {
-    "clamper": "1.0.2"
+    "clamper": "~1.0.2",
+    "prop-types": "~15.5.10"
   },
   "peerDependencies": {
     "react": "^0.14.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var clamp = require('clamper');
-var PropTypes = require('prop-types')
+var PropTypes = require('prop-types');
 /**
  * multuline text-overflow: ellipsis
  */

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var clamp = require('clamper');
-var PropTypes = React.PropTypes;
+var PropTypes = require('prop-types')
 /**
  * multuline text-overflow: ellipsis
  */


### PR DESCRIPTION
This remove warning messare related with `React.propTypes` is deprecated.